### PR TITLE
Comment out dead code in rebuild.sh so it runs

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -84,7 +84,8 @@ rustc --version | awk '{print $2}' > "$dest_path/RUST_VERSION"
 # Remove stale objects
 rm -f $dest_lib_path/*.rlib
 
-previous_libraries=$(ls -1 $src_path/*.rlib)
+# TODO: Use below to remove duplicates
+# previous_libraries=$(ls -1 $src_path/*.rlib)
 
 cargo build \
     --target riscv32imac-unknown-xous-elf \

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -32,7 +32,7 @@ export RUSTFLAGS="-Cforce-unwind-tables=yes -Cembed-bitcode=yes"
 export __CARGO_DEFAULT_LIB_METADATA="stablestd"
 
 command_exists() {
-    which $1 > /dev/null && $1 --version 2>&1 > /dev/null
+    which $1 &> /dev/null && $1 --version 2>&1 > /dev/null
 }
 
 # Set up the C compiler. We need to explicitly specify these variables


### PR DESCRIPTION
Currently users trying to run the `rebuild.sh` script for the first time experience an error relating to this particular line. Since it's currently dead code, it's easiest just to comment it out and attach a related TODO.

I also took the liberty of fixing a `which` pipe so it didn't show the user a non-error. Please let me know if you'd like that split into a separate PR.

Prior:

```bash
[ana@architect rust]$ ./rebuild.sh 
which: no riscv32-unknown-elf-gcc in (/home/ana/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/home/ana/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/ana/.cargo/bin:/home/ana/git/riscv-collab/riscv-gnu-toolchain/result/bin:/home/ana/.cargo/bin:/home/ana/git/riscv-collab/riscv-gnu-toolchain/result/bin)
which: no riscv-none-embed-gcc in (/home/ana/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/home/ana/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/ana/.cargo/bin:/home/ana/git/riscv-collab/riscv-gnu-toolchain/result/bin:/home/ana/.cargo/bin:/home/ana/git/riscv-collab/riscv-gnu-toolchain/result/bin)
ls: cannot access './target/riscv32imac-unknown-xous-elf/release/deps/*.rlib': No such file or directory
```

After:

```bash
[ana@architect rust]$ ./rebuild.sh 
[ana@architect rust]$ ./rebuild.sh 
warning: dropping unsupported crate type `dylib` for target `riscv32imac-unknown-xous-elf`

warning: `std` (lib) generated 1 warning
warning: `test` (lib) generated 1 warning (1 duplicate)
    Finished release [optimized] target(s) in 0.14s
```