### PR TITLE
Carefully check all scalar2's for argument order

### DIFF
--- a/library/std/src/os/xous/services/pddb.rs
+++ b/library/std/src/os/xous/services/pddb.rs
@@ -67,14 +67,21 @@ impl<'a> Into<[usize; 5]> for PddbBlockingScalar {
         match self {
             PddbBlockingScalar::SeekKeyStd(fd, from) => {
                 let (a1, a2, a3) = match from {
+                    /*
+                    Opcode::SeekKeyStd => {
+                        let fd = (msg.body.id() >> 16) & 0xffff;
+                        if let Some(scalar) = msg.body.scalar_message() {
+                            let seek_by = (((scalar.arg2 as u32) as u64) << 32) | ((scalar.arg3 as u32) as u64);
+                     */
+                    // arg2 is the MSB, arg3 is the LSB
                     SeekFrom::Start(off) => {
-                        (0, (off as usize & 0xffff_ffff), ((off >> 32) as usize) & 0xffff_ffff)
+                        (0, ((off >> 32) as usize) & 0xffff_ffff, (off as usize & 0xffff_ffff))
                     }
                     SeekFrom::Current(off) => {
-                        (1, (off as usize & 0xffff_ffff), ((off >> 32) as usize) & 0xffff_ffff)
+                        (1, ((off >> 32) as usize) & 0xffff_ffff, (off as usize & 0xffff_ffff))
                     }
                     SeekFrom::End(off) => {
-                        (2, (off as usize & 0xffff_ffff), ((off >> 32) as usize) & 0xffff_ffff)
+                        (2, ((off >> 32) as usize) & 0xffff_ffff, (off as usize & 0xffff_ffff))
                     }
                 };
                 [39 | ((fd as usize) << 16), a1, a2, a3, 0]

--- a/library/std/src/os/xous/services/ticktimer.rs
+++ b/library/std/src/os/xous/services/ticktimer.rs
@@ -16,10 +16,25 @@ impl Into<[usize; 5]> for TicktimerScalar {
     fn into(self) -> [usize; 5] {
         match self {
             TicktimerScalar::ElapsedMs => [0, 0, 0, 0, 0],
+            /*
+            if let Some(scalar) = msg.body.scalar_message_mut() {
+                let ms = scalar.arg1 as i64;
+             */
             TicktimerScalar::SleepMs(msecs) => [1, msecs, 0, 0, 0],
             TicktimerScalar::LockMutex(cookie) => [6, cookie, 0, 0, 0],
             TicktimerScalar::UnlockMutex(cookie) => [7, cookie, 0, 0, 0],
+            /*
+            api::Opcode::WaitForCondition => {
+                let pid = msg.sender.pid();
+                let condvar = scalar.arg1;
+                let timeout = scalar.arg2;
+             */
             TicktimerScalar::WaitForCondition(cookie, timeout_ms) => [8, cookie, timeout_ms, 0, 0],
+            /*
+            api::Opcode::NotifyCondition => {
+                let condvar = scalar.arg1;
+                let mut requested_count: usize = scalar.arg2;
+             */
             TicktimerScalar::NotifyCondition(cookie, count) => [9, cookie, count, 0, 0],
             TicktimerScalar::FreeMutex(cookie) => [10, cookie, 0, 0, 0],
             TicktimerScalar::FreeCondition(cookie) => [11, cookie, 0, 0, 0],

--- a/library/std/src/sys/xous/time.rs
+++ b/library/std/src/sys/xous/time.rs
@@ -16,8 +16,13 @@ impl Instant {
     pub fn now() -> Instant {
         let result = blocking_scalar(ticktimer_server(), ElapsedMs.into())
             .expect("failed to request elapsed_ms");
-        let lower = result[0];
-        let upper = result[1];
+        /* if let Some(scalar) = msg.body.scalar_message_mut() {
+              let time = ticktimer.elapsed_ms() as i64;
+              scalar.arg1 = (time & 0xFFFF_FFFFi64) as usize;
+              scalar.arg2 = ((time >> 32) & 0xFFF_FFFFi64) as usize;
+        */
+        let lower = result[0]; // corresponds to ScalarMessage.arg1
+        let upper = result[1]; // corresponds to ScalarMessage.arg2
         Instant { 0: Duration::from_millis(lower as u64 | (upper as u64) << 32) }
     }
 
@@ -38,8 +43,20 @@ impl SystemTime {
     pub fn now() -> SystemTime {
         let result = blocking_scalar(systime_server(), GetUtcTimeMs.into())
             .expect("failed to request utc time in ms");
-        let lower = result[0];
-        let upper = result[1];
+        /*
+            Some(TimeOp::GetUtcTimeMs) => xous::msg_blocking_scalar_unpack!(msg, _, _, _, _, {
+                let t =
+                    start_rtc_secs as i64 * 1000i64
+                    + (tt.elapsed_ms() - start_tt_ms) as i64;
+                log::debug!("hw only UTC ms {}", t);
+                xous::return_scalar2(msg.sender,
+                    (((t as u64) >> 32) & 0xFFFF_FFFF) as usize,
+                    (t as u64 & 0xFFFF_FFFF) as usize,
+                ).expect("couldn't respond to GetUtcTimeMs");
+            }),
+        */
+        let upper = result[0]; // val1
+        let lower = result[1]; // val2
         SystemTime { 0: Duration::from_millis((upper as u64) << 32 | lower as u64) }
     }
 


### PR DESCRIPTION
Two scalar2's were found to have argument orders flipped in the std re-implementation.

I have included the reference code from the Xous side, can you please check the code comments and see if you agree that the calls to `SeekKeyStd` and `GetTimeUtcMs` are flipped?

The other calls I just added lots and lots of comments around them.