### PR TITLE
Don't mark thread stack as X

### DIFF
--- a/library/std/src/sys/thread/xous.rs
+++ b/library/std/src/sys/thread/xous.rs
@@ -36,7 +36,7 @@ impl Thread {
                 None,
                 None,
                 GUARD_PAGE_SIZE + stack_size + GUARD_PAGE_SIZE,
-                MemoryFlags::R | MemoryFlags::W | MemoryFlags::X,
+                MemoryFlags::R | MemoryFlags::W,
             )
         }
         .map_err(|code| io::Error::from_raw_os_error(code as i32))?;


### PR DESCRIPTION
I am not sure, but I think there should be no reason to mark a thread's stack as executable - doing so just means that data on the stack can be used as a gadget for launching exploits?

At the moment, the stack guard - which in and of itself should be inert? is marked X on alloc.

What then happens is that X is propagated through the entire life cycle of the stack, because there is nothing that gates it off, leading to a stack pattern that looks like this:

```
         466 601d2000 -> 00000000 (flags: R | W | X)
         467 601d3000 -> 00000000 (flags: R | W | X)
         468 601d4000 -> 00000000 (flags: R | W | X)
         469 601d5000 -> 6106e000 (flags: VALID | R | W | X | USER | A | D)
         470 601d6000 -> 61147000 (flags: VALID | R | W | X | USER | A | D)
         471 601d7000 -> 611df000 (flags: VALID | R | W | X | USER | A | D)
         472 601d8000 -> 61064000 (flags: VALID | R | W | X | USER | A | D)
         473 601d9000 -> 00000000 (flags: R | W | X)
         474 601da000 -> 6114f000 (flags: VALID | R | W | X | USER | A | D)
         475 601db000 -> 00000000 (flags: W)
         476 601dc000 -> 611f6000 (flags: VALID | R | W | USER | A | D)
         478 601de000 -> 6105a000 (flags: VALID | R | W | USER | A | D)
         489 601e9000 -> 610a9000 (flags: R | W | USER | A | D | S)
         490 601ea000 -> 610b2000 (flags: VALID | R | W | A | D)
         491 601eb000 -> 00000000 (flags: W)
         492 601ec000 -> 00000000 (flags: R | W | X)
         493 601ed000 -> 00000000 (flags: R | W | X)
```

I think what we're seeing here are the reserved pages at 601d2000 (RWX), and then some valid stack at 601d5000, which is ... executable, because the VALID/USER/A/D bits are OR'd into the existing flags. I think the other pages
not marked valid might have been...remnants of memory messages? swapped memory? not really sure how we end up with just a W flag on a page and nothing else. But if you look at a stack dump for any process that has threads there are dozens of pages just marked RWX which then get "up-cycled" into live pages that have an X bit on them.

Is there an easy way to try this out without having to push a whole new tag and have it break everything? I forgot how to build `std` locally, unfortunately.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
